### PR TITLE
Fix: 충돌 후 누락 코드 복원

### DIFF
--- a/RtanTextDungeonTeam17/RtanTextDungeon/Dungeon.cs
+++ b/RtanTextDungeonTeam17/RtanTextDungeon/Dungeon.cs
@@ -541,7 +541,8 @@ namespace RtanTextDungeon
                     {
                         case "1":
                             Fight(monsters, startHp);
-                            return;
+                            invalid = false;
+                            break;
                         case "2":
                             isSkillShow = true; //스킬 선택 화면으로
                             break;


### PR DESCRIPTION
- 대상선택 -> 취소 시 던전입구로 가는 현상 해결
- 몬스터 공격 페이즈 1회 후 던전입구로 가는 현상 해결