### PR TITLE
Fix: 플레이어 Load 시 생성 객체 고정 버그 수정

### DIFF
--- a/RtanTextDungeonTeam17/RtanTextDungeon/DataManager.cs
+++ b/RtanTextDungeonTeam17/RtanTextDungeon/DataManager.cs
@@ -18,13 +18,13 @@ namespace RtanTextDungeon
         #region Save
         // 게임 세이브 - T 타입 정보 저장
         public static void SaveGame<T>(T data, string fileName)
-        {            
+        {
             string savePath = Path.Combine(DIRECTORY_NAME, fileName);
             string dataFile = JsonSerializer.Serialize(data, new JsonSerializerOptions() { WriteIndented = true });
             dataFile = Regex.Unescape(dataFile);
 
             File.WriteAllText(savePath, dataFile);
-        }
+        }       
         #endregion
 
         #region Load

--- a/RtanTextDungeonTeam17/RtanTextDungeon/Define.cs
+++ b/RtanTextDungeonTeam17/RtanTextDungeon/Define.cs
@@ -10,7 +10,7 @@ namespace RtanTextDungeon
     {
         public enum PlayerClass
         {
-            Worrior,
+            Warrior,
             Archer,
             Magic,
             Thief,

--- a/RtanTextDungeonTeam17/RtanTextDungeon/Dungeon.cs
+++ b/RtanTextDungeonTeam17/RtanTextDungeon/Dungeon.cs
@@ -27,7 +27,27 @@ namespace RtanTextDungeon
         #region 게임시작
         public void EnterGame()
         {
-            player = LoadGame<Player>("PlayerData.json");
+            if (LoadGame<Player>("PlayerData.json") != null)
+            {
+                switch (LoadGame<Player>("PlayerData.json").MyClass)
+                {
+                    case PlayerClass.Warrior:
+                        player = LoadGame<Warrior>("PlayerData.json");
+                        break;
+                    case PlayerClass.Archer:
+                        player = LoadGame<Archer>("PlayerData.json");
+                        break;
+                    case PlayerClass.Magic:
+                        player = LoadGame<Magic>("PlayerData.json");
+                        break;
+                    case PlayerClass.Thief:
+                        player = LoadGame<Thief>("PlayerData.json");
+                        break;
+                    case PlayerClass.Deadbeat:
+                        player = LoadGame<Deadbeat>("PlayerData.json");
+                        break;
+                }
+            }
 
             if (player == null)
                 CharacterCreation();
@@ -159,7 +179,7 @@ namespace RtanTextDungeon
                 Console.Clear();// 콘솔 화면 한 번 지우기
                 switch (input)
                 {
-                    case "1":
+                    case "1":                        
                         player = new Warrior(name);
                         break;
                     case "2":

--- a/RtanTextDungeonTeam17/RtanTextDungeon/Player.cs
+++ b/RtanTextDungeonTeam17/RtanTextDungeon/Player.cs
@@ -13,7 +13,7 @@ namespace RtanTextDungeon
     {
         public int Lv                       { get; set; }
         public string Name                  { get; private set; }        
-        public PlayerClass m_Class          { get; private set; }
+        public PlayerClass MyClass          { get; private set; }
         public float Atk                    { get; private set; }
         public int Def                      { get; private set; }
         public int Hp                       { get; private set; }
@@ -30,11 +30,11 @@ namespace RtanTextDungeon
         // 런타임에서 가지고 있을 장착 아이템 정보들
         public Dictionary<string, Item>       equippedItems = new Dictionary<string, Item>();
 
-        public Player(int Lv, string Name, PlayerClass m_Class, float Atk, int Def, int MaxHp, int MaxMp, int Gold, int point, List<Skill> Skills = null, List<int> Items = null, List<int> EquippedItemsIndex = null)
+        public Player(int Lv, string Name, PlayerClass MyClass, float Atk, int Def, int MaxHp, int MaxMp, int Gold, int point, List<Skill> Skills = null, List<int> Items = null, List<int> EquippedItemsIndex = null)
         {
             this.Lv = Lv;
             this.Name = Name;
-            this.m_Class = m_Class;
+            this.MyClass = MyClass;
             this.Atk = Atk;
             this.Def = Def;
             this.Hp = MaxHp;
@@ -51,7 +51,7 @@ namespace RtanTextDungeon
                 this.Items = new List<int>();
             if (this.EquippedItemsIndex == null)
                 this.EquippedItemsIndex = new List<int>();
-        }        
+        }   
 
         public void BuyOrSell(int price, Item item, bool isSell = false)
         {            
@@ -218,7 +218,7 @@ namespace RtanTextDungeon
     #region 하위 직업들
     internal class Warrior : Player
     {
-        public Warrior(string name) : base (1, name, PlayerClass.Worrior, 10, 5, 100, 100, 1500, 0)
+        public Warrior(string name, List<Skill> Skills = null, List<int> Items = null, List<int> EquippedItemsIndex = null) : base(1, name, PlayerClass.Warrior, 10, 5, 100, 100, 1500, 0, Skills, Items, EquippedItemsIndex)
         {
             CreateSkills();
         }
@@ -237,7 +237,7 @@ namespace RtanTextDungeon
 
     internal class Archer : Player
     {
-        public Archer(string name) : base(1, name, PlayerClass.Archer, 12, 3, 90, 100, 1500, 0)
+        public Archer(string name, List<Skill> Skills = null, List<int> Items = null, List<int> EquippedItemsIndex = null) : base(1, name, PlayerClass.Archer, 12, 3, 90, 100, 1500, 0, Skills, Items, EquippedItemsIndex)
         {
             CreateSkills();
         }
@@ -256,7 +256,7 @@ namespace RtanTextDungeon
 
     internal class Magic : Player
     {
-        public Magic(string name) : base(1, name, PlayerClass.Magic, 10, 4, 80, 120, 1500, 0)
+        public Magic(string name, List<Skill> Skills = null, List<int> Items = null, List<int> EquippedItemsIndex = null) : base(1, name, PlayerClass.Magic, 10, 4, 80, 120, 1500, 0, Skills, Items, EquippedItemsIndex)
         {
             CreateSkills();
         }
@@ -275,7 +275,7 @@ namespace RtanTextDungeon
 
     internal class Thief : Player
     {
-        public Thief(string name) : base(1, name, PlayerClass.Thief, 11, 4, 80, 100, 1500, 0)
+        public Thief(string name, List<Skill> Skills = null, List<int> Items = null, List<int> EquippedItemsIndex = null) : base(1, name, PlayerClass.Thief, 11, 4, 80, 100, 1500, 0, Skills, Items, EquippedItemsIndex)
         {
             CreateSkills();
         }
@@ -294,7 +294,7 @@ namespace RtanTextDungeon
 
     internal class Deadbeat : Player
     {
-        public Deadbeat(string name) : base(1, name, PlayerClass.Deadbeat, 6, 5, 100, 100, 500, 0)
+        public Deadbeat(string name, List<Skill> Skills = null, List<int> Items = null, List<int> EquippedItemsIndex = null) : base(1, name, PlayerClass.Deadbeat, 6, 5, 100, 100, 500, 0, Skills, Items, EquippedItemsIndex)
         {
             CreateSkills();
         }

--- a/RtanTextDungeonTeam17/RtanTextDungeon/Program.cs
+++ b/RtanTextDungeonTeam17/RtanTextDungeon/Program.cs
@@ -9,8 +9,11 @@ namespace RtanTextDungeon
     {
         static void Main(string[] args)
         {
-            Console.WindowWidth = 144;
-            Console.WindowHeight = 48;
+            //Console.WindowWidth = 144;
+            //Console.WindowHeight = 48;
+
+            Console.WindowWidth = 200;
+            Console.WindowHeight = 70;
 
             // 타이틀 화면
             UI.AsciiArt(UI.AsciiPreset.TitleArt);

--- a/RtanTextDungeonTeam17/RtanTextDungeon/Program.cs
+++ b/RtanTextDungeonTeam17/RtanTextDungeon/Program.cs
@@ -9,11 +9,8 @@ namespace RtanTextDungeon
     {
         static void Main(string[] args)
         {
-            //Console.WindowWidth = 144;
-            //Console.WindowHeight = 48;
-
-            Console.WindowWidth = 200;
-            Console.WindowHeight = 70;
+            Console.WindowWidth = 144;
+            Console.WindowHeight = 48;
 
             // 타이틀 화면
             UI.AsciiArt(UI.AsciiPreset.TitleArt);


### PR DESCRIPTION
기존 - 플레이어 로드 시, Player 객체 생성.
해당 방식은 상태창에서 "직업명" -> "잘못된 접근" 으로 표기됨.
변경 - 플레이어 로드 시, Warrior/Archer 등 저장시점의 클래스로 객체 생성.
"직업명" 정상표기.